### PR TITLE
Forbid size and page values smaller than 0

### DIFF
--- a/src/lib/msw/handlers.ts
+++ b/src/lib/msw/handlers.ts
@@ -202,6 +202,12 @@ export const handlers: RequestHandler[] = [
     const size = Number.parseInt(url.searchParams.get('size') ?? '10')
     const page = Number.parseInt(url.searchParams.get('page') ?? '0')
 
+    if (size < 0) {
+      return HttpResponse.json<ResponseType>({ message: 'wrong size value' }, { status: 400 })
+    }
+    if (page < 0) {
+      return HttpResponse.json<ResponseType>({ message: 'wrong page value' }, { status: 400 })
+    }
     if (size > 10) {
       return HttpResponse.json<ResponseType>({ message: "size can't be larger than 10" }, { status: 400 })
     }


### PR DESCRIPTION
With the current implementation, we could download all matches passing a `size=-1`.

This is un-intended bug and would allow candidates to download everything in one go (which is not the point of the task).